### PR TITLE
Match pattern '+=' and '=>' 

### DIFF
--- a/syntaxes/lit-html.json
+++ b/syntaxes/lit-html.json
@@ -16,7 +16,7 @@
 			"name": "string.js.taggedTemplate",
 			"contentName": "meta.embedded.block.html",
             "begin_a": "(\\s?\\/?\\*?\\s?(html|sql|SQL|inline-sql|inline-SQL)\\s?\\*?\\/?\\s?)(`)",
-            "begin": "(\\w+)\\s*?(=\\s*?)(\\s?\\/\\*\\s?(html|template|inline-html|inline-template)\\s?\\*\\/\\s?)?(`)",
+            "begin": "(\\w+)\\s*?(\\+?=\\>?\\s*?)(\\s?\\/\\*\\s?(html|template|inline-html|inline-template)\\s?\\*\\/\\s?)?(`)",
 			"beginCaptures": {
 				"1": {
 					"name": "entity.name.function.tagged-template.js"


### PR DESCRIPTION
### Problem

When the string does not start with `=` the extension does not detect the template to make the highlight.
As already mentioned here #2 

### Solution

Added `+` and `>` operator in regex to make correct match.